### PR TITLE
Store lastQuery and lastMutation context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,9 @@ const getResultFromFetchResult = (result: FetchResult | (() => FetchResult)): Fe
 
 interface QueryAndVariables {
   query: DocumentNode
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   variables: GraphQLVariables
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context: Record<string, any>;
 }
 
 /**
@@ -76,11 +77,13 @@ export class WildcardMockLink extends MockLink {
       this.lastMutation = {
         query: op.query,
         variables: op.variables,
+        context: op.getContext(),
       }
     } else {
       this.lastQuery = {
         query: op.query,
         variables: op.variables,
+        context: op.getContext(),
       }
     }
 


### PR DESCRIPTION
Keeping the context would be helpful if one needs to test the headers that went out with the last query/mutation.