### PR TITLE
Adding an option to suppress missing mock warnings.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ return (
 
 The above mocked provider will match two requests for `CAT_QUALITIES_QUERY` no matter what the variables are. Here `nMatches` is used to restrict the mock to the first two requests that match, when `nMatches` is omitted the mock will match one request. `Number.POSITIVE_INFINITY` can be used to allow an inifinite number of matchs.
 
-The instantiation of `WildcardMockLink` also shows the options, `addTypename` which works the same as apollo's `MockLink` and `act` which can be used to ensure all operations that emit data to components are wrapped in an `act` function.
+The instantiation of `WildcardMockLink` also shows the options, `addTypename` which works the same as apollo's `MockLink` and `act` which can be used to ensure all operations that emit data to components are wrapped in an `act` function. `suppressMissingMockWarnings` will disable the `console.warn` about missing mocks, defaults to `false`. 
 
 ### Asserting against the latest request/mutation/subscription.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ interface Act {
 export interface WildcardMockLinkOptions {
   addTypename?: boolean
   act?: Act
+  suppressMissingMockWarnings?: boolean
 }
 
 // MockedResponseWithMatchCount is a narrower type than WildcardMockedResponse so it
@@ -154,12 +155,13 @@ export class WildcardMockLink extends ApolloLink {
   private lastResponse?: Promise<void>
   private act: Act
   public addTypename: boolean
+  public suppressMissingMockWarnings = false
 
   private openSubscriptions = new Map<string, FetchResultObserver>()
 
   constructor(
     mockedResponses: MockedResponses,
-    public options: boolean | WildcardMockLinkOptions = { addTypename: true },
+    public options: boolean | WildcardMockLinkOptions = { addTypename: true, suppressMissingMockWarnings: false },
   ) {
     super()
 
@@ -168,6 +170,7 @@ export class WildcardMockLink extends ApolloLink {
       this.addTypename = options
     } else {
       this.addTypename = options.addTypename ?? true
+      this.suppressMissingMockWarnings = options.suppressMissingMockWarnings ?? false
       this.act = options.act ?? callFunction
     }
 
@@ -209,7 +212,9 @@ export class WildcardMockLink extends ApolloLink {
         const errorString = `No mocks matched ${op.operationName}: ${print(
           op.query,
         )}, variables: ${JSON.stringify(op.variables)}`
-        console.warn(errorString)
+        if (!this.suppressMissingMockWarnings) {
+          console.warn(errorString)
+        }
         return observableWithError(new Error(errorString))
       } else if (!regularMock.error && !regularMock.result) {
         return observableWithError(
@@ -241,7 +246,9 @@ export class WildcardMockLink extends ApolloLink {
         const errorString = `No mocks matched ${op.operationName}: ${print(
           op.query,
         )}, variables: ${JSON.stringify(op.variables)}`
-        console.warn(errorString)
+        if (!this.suppressMissingMockWarnings) {
+          console.warn(errorString)
+        }
         return observableWithError(new Error(errorString))
       }
 


### PR DESCRIPTION
This is useful if you're testing large components that make queries or mutations that you're not interested in the response as part of the test. Reduces console spam at the risk of missing wanted warnings.

Open to any suggestions!