### PR TITLE
Pass variables to result function

### DIFF
--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -1,9 +1,4 @@
-import {
-  FetchResult,
-  GraphQLRequest,
-  useQuery,
-  useSubscription,
-} from '@apollo/client'
+import { FetchResult, useQuery, useSubscription } from '@apollo/client'
 import { render, act, waitFor } from '@testing-library/react'
 import { renderHook, act as actHook } from '@testing-library/react-hooks'
 import gql from 'graphql-tag'
@@ -140,7 +135,7 @@ describe('WildcardMockLink', () => {
         const data = {
           qualities: {
             __typename: 'Qualities',
-            loveliness: 'ok',
+            loveliness: 'scruffy',
           },
         }
         const { wrapper, link } = hookWrapperWithApolloMocks(
@@ -151,10 +146,14 @@ describe('WildcardMockLink', () => {
                 variables: MATCH_ANY_PARAMETERS,
               },
               result: (variables): FetchResult => {
-                if (variables?.catName === 'scruffy') {
-                  return { data }
+                return {
+                  data: {
+                    qualities: {
+                      __typename: 'Qualities',
+                      loveliness: variables?.catName,
+                    },
+                  },
                 }
-                return { data: {} }
               },
             },
           ],

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -1,4 +1,4 @@
-import { FetchResult, useQuery, useSubscription } from '@apollo/client'
+import { useQuery, useSubscription } from '@apollo/client'
 import { render, act, waitFor } from '@testing-library/react'
 import { renderHook, act as actHook } from '@testing-library/react-hooks'
 import gql from 'graphql-tag'
@@ -145,7 +145,7 @@ describe('WildcardMockLink', () => {
                 query: CAT_QUALITIES_QUERY,
                 variables: MATCH_ANY_PARAMETERS,
               },
-              result: (variables): FetchResult => {
+              result: (variables) => {
                 return {
                   data: {
                     qualities: {

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -150,9 +150,7 @@ describe('WildcardMockLink', () => {
                 query: CAT_QUALITIES_QUERY,
                 variables: MATCH_ANY_PARAMETERS,
               },
-              result: (
-                variables: GraphQLRequest['variables'] | undefined,
-              ): FetchResult => {
+              result: (variables): FetchResult => {
                 if (variables?.catName === 'scruffy') {
                   return { data }
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,7 @@ export interface GraphQLRequestWithWildcard
 interface MockedResponseWithMatchCount extends Omit<MockedResponse, 'result'> {
   /** Use Number.POSITIVE_INFINITY to allow infinite matches */
   nMatches?: number
-  result?:
-    | FetchResult
-    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult)
+  result?: FetchResult | ((variables?: GraphQLVariables) => FetchResult)
 }
 
 type WildcardMock = Omit<MockedResponseWithMatchCount, 'request'> & {
@@ -49,9 +47,7 @@ type WildcardMock = Omit<MockedResponseWithMatchCount, 'request'> & {
 export interface WildcardMockedResponse
   extends Omit<Omit<WildcardMock, 'request'>, 'result'> {
   request: GraphQLRequestWithWildcard
-  result?:
-    | FetchResult
-    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult)
+  result?: FetchResult | ((variables?: GraphQLVariables) => FetchResult)
 }
 
 export type MockedResponses = readonly WildcardMockedResponse[]
@@ -76,10 +72,8 @@ function isNotWildcard(
 }
 
 const getResultFromFetchResult = (
-  result:
-    | FetchResult
-    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult),
-  variables: GraphQLRequest['variables'] | undefined,
+  result: FetchResult | ((variables?: GraphQLVariables) => FetchResult),
+  variables?: GraphQLVariables,
 ): FetchResult => (typeof result === 'function' ? result(variables) : result)
 
 interface StoredOperation {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,15 +34,24 @@ export interface GraphQLRequestWithWildcard
   variables?: GraphQLRequest['variables'] | typeof MATCH_ANY_PARAMETERS
 }
 
-interface MockedResponseWithMatchCount extends MockedResponse {
+interface MockedResponseWithMatchCount extends Omit<MockedResponse, 'result'> {
   /** Use Number.POSITIVE_INFINITY to allow infinite matches */
   nMatches?: number
+  result?:
+    | FetchResult
+    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult)
 }
 
-type WildcardMock = Omit<MockedResponseWithMatchCount, 'request'>
+type WildcardMock = Omit<MockedResponseWithMatchCount, 'request'> & {
+  request: GraphQLRequest
+}
 
-export interface WildcardMockedResponse extends WildcardMock {
+export interface WildcardMockedResponse
+  extends Omit<Omit<WildcardMock, 'request'>, 'result'> {
   request: GraphQLRequestWithWildcard
+  result?:
+    | FetchResult
+    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult)
 }
 
 export type MockedResponses = readonly WildcardMockedResponse[]
@@ -67,8 +76,11 @@ function isNotWildcard(
 }
 
 const getResultFromFetchResult = (
-  result: FetchResult | (() => FetchResult),
-): FetchResult => (typeof result === 'function' ? result() : result)
+  result:
+    | FetchResult
+    | ((variables: GraphQLRequest['variables'] | undefined) => FetchResult),
+  variables: GraphQLRequest['variables'] | undefined,
+): FetchResult => (typeof result === 'function' ? result(variables) : result)
 
 interface StoredOperation {
   query: DocumentNode
@@ -90,11 +102,11 @@ const forwardResponseToObserver = (
   complete: boolean,
   act: Act,
 ): void => {
-  const { result, error, delay } = response
+  const { result, error, delay, request } = response
   if (result) {
     setTimeout(() => {
       act(() => {
-        observer.next(getResultFromFetchResult(result))
+        observer.next(getResultFromFetchResult(result, request.variables))
       })
       if (complete) {
         observer.complete()
@@ -347,6 +359,13 @@ export class WildcardMockLink extends ApolloLink {
           result: response.result,
           nMatches: response.nMatches,
           delay: response.delay ?? 0,
+          request: {
+            ...response.request,
+            variables:
+              response.request.variables === MATCH_ANY_PARAMETERS
+                ? undefined
+                : response.request.variables,
+          },
         }
         if (storedMocks) {
           storedMocks.push(storedMock)
@@ -469,7 +488,10 @@ export class WildcardMockLink extends ApolloLink {
         this.wildcardMatches.delete(mockKey)
       }
     }
-    return nextMock
+    return {
+      ...nextMock,
+      request: { ...nextMock.request, variables: op.variables },
+    }
   }
 
   private getRegularMockMatch(
@@ -501,7 +523,6 @@ export class WildcardMockLink extends ApolloLink {
           this.pendingResponses.delete(responsePromise)
         })
       })
-
       this.lastResponse = responsePromise
       this.pendingResponses.add(responsePromise)
     }


### PR DESCRIPTION
Thought it would be handy when using a result function to be able to pass the query variables into the function, so they could be used to help generate the mock data.

Had a go at updating the code to make it so and it seems to work OK. Have also added a test around the functionality.