### PR TITLE
Type a mocked response with Data and Variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,20 +37,32 @@ export interface GraphQLRequestWithWildcard
   variables?: GraphQLRequest['variables'] | typeof MATCH_ANY_PARAMETERS
 }
 
-interface MockedResponseWithMatchCount extends Omit<MockedResponse, 'result'> {
+type MockedResult<TData = Record<string, any>, TVars = GraphQLVariables> =
+  | FetchResult<TData>
+  |((variables?: TVars) => TData)
+
+interface MockedResponseWithMatchCount<
+  TData = Record<string, any>,
+  TVars = GraphQLVariables,
+> extends Omit<MockedResponse<TData>, 'result'> {
   /** Use Number.POSITIVE_INFINITY to allow infinite matches */
   nMatches?: number
-  result?: FetchResult | ((variables?: GraphQLVariables) => FetchResult)
+  result?: MockedResult<TData, TVars>
 }
 
-type WildcardMock = Omit<MockedResponseWithMatchCount, 'request'> & {
+type WildcardMock<TData = Record<string, any>, TVars = GraphQLVariables> = Omit<
+  MockedResponseWithMatchCount<TData, TVars>,
+  'request'
+> & {
   request: GraphQLRequest
 }
 
-export interface WildcardMockedResponse
-  extends Omit<Omit<WildcardMock, 'request'>, 'result'> {
+export interface WildcardMockedResponse<
+  TData = Record<string, any>,
+  TVars = GraphQLVariables,
+> extends Omit<Omit<WildcardMock<TData, TVars>, 'request'>, 'result'> {
   request: GraphQLRequestWithWildcard
-  result?: FetchResult | ((variables?: GraphQLVariables) => FetchResult)
+  result?: MockedResult<TData, TVars>
 }
 
 export type MockedResponses = readonly WildcardMockedResponse[]
@@ -75,7 +87,7 @@ function isNotWildcard(
 }
 
 const getResultFromFetchResult = (
-  result: FetchResult | ((variables?: GraphQLVariables) => FetchResult),
+  result: MockedResult,
   variables?: GraphQLVariables,
 ): FetchResult => (typeof result === 'function' ? result(variables) : result)
 


### PR DESCRIPTION
Hey, great library :+1:.

I wanted to enhanced the type system serving mocks, with:
- Passing a TData representing the expected type for the `data` field
- Passing a TVars representing the expected type for the `variables` of an operation (query/mutation)

It was helpful for me in order to create mocks that are type checked and also provide a function to return different values given the `variables`.

Let me know if things are missing :)